### PR TITLE
Add proxy support for HTTP requests

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -21,8 +21,9 @@ HOST = "https://api.pushbullet.com/v2"
 
 
 class PushBullet():
-    def __init__(self, apiKey):
+    def __init__(self, apiKey, proxies=None):
         self.apiKey = apiKey
+        self.proxies = proxies
 
     def _request(self, method, url, postdata=None, params=None, files=None):
         headers = {"Accept": "application/json",
@@ -38,7 +39,8 @@ class PushBullet():
                              params=params,
                              headers=headers,
                              files=files,
-                             auth=HTTPBasicAuth(self.apiKey, ""))
+                             auth=HTTPBasicAuth(self.apiKey, ""),
+                             proxies=self.proxies)
 
         r.raise_for_status()
         return r.json()


### PR DESCRIPTION
This adds explicit proxy support for API endpoints using standard HTTP requests. In many cases, `requests` simply reads the `HTTP_PROXY` and `HTTPS_PROXY` environment variables. However, in my case, I have (closed-source) software that treats HTTPS_PROXY differently than everything else, so I cannot set it without causing errors. This change allows me to patch my unusual environment.

Usage:
```python
pb = PushBullet('xxx', {'http': 'http://10.0.0.1:8100', 'https': 'https://10.0.0.1:8101'})
```

The format and behavior is exactly as defined here: http://docs.python-requests.org/en/master/user/advanced/#proxies